### PR TITLE
Implementa recuperação de senha

### DIFF
--- a/config/DB.txt
+++ b/config/DB.txt
@@ -92,6 +92,16 @@ CREATE TABLE IF NOT EXISTS `usuarios` (
   UNIQUE KEY `email` (`email`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
 
+CREATE TABLE IF NOT EXISTS `password_resets` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `usuario_id` int NOT NULL,
+  `token_hash` varchar(64) NOT NULL,
+  `expires_at` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `usuario_id` (`usuario_id`),
+  CONSTRAINT `password_resets_ibfk_1` FOREIGN KEY (`usuario_id`) REFERENCES `usuarios` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
+
 CREATE TABLE IF NOT EXISTS `vendedores` (
   `id` int NOT NULL AUTO_INCREMENT,
   `nome` varchar(100) COLLATE utf8mb4_general_ci NOT NULL,

--- a/login.php
+++ b/login.php
@@ -56,12 +56,16 @@ $msg = $_GET['msg'] ?? null;
       </button>
     </form>
     <div class="mt-3 sm:mt-4 text-center">
-      <a href="#" class="text-gray-400 hover:text-yellow-400 transition text-sm sm:text-base">Esqueceu a senha?.w</a>
+      <a href="recuperar_senha.php" class="text-gray-400 hover:text-yellow-400 transition text-sm sm:text-base">Esqueceu a senha?</a>
     </div>
   </div>
-    <?php if ($msg === 'sessao_expirada'): ?>
+    <?php if ($msg === 'sessao_expirada' || $msg === 'senha_redefinida'): ?>
     <div id="toast-msg" class="fixed top-4 right-4 bg-yellow-500 text-gray-900 px-4 py-3 rounded shadow-lg z-50 transition-opacity duration-300 opacity-0">
-      Sua sessão expirou por inatividade.
+      <?php if ($msg === 'sessao_expirada'): ?>
+        Sua sessão expirou por inatividade.
+      <?php else: ?>
+        Senha atualizada com sucesso.
+      <?php endif; ?>
     </div>
     <script>
       const toast = document.getElementById('toast-msg');

--- a/recuperar_senha.php
+++ b/recuperar_senha.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/config/db.php';
+require_once __DIR__ . '/config/app.php';
+
+$sucesso = isset($_GET['ok']);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = trim($_POST['email'] ?? '');
+    if ($email !== '') {
+        $stmt = $pdo->prepare('SELECT id, nome FROM usuarios WHERE email = :email AND ativo = 1');
+        $stmt->execute(['email' => $email]);
+        $user = $stmt->fetch();
+        if ($user) {
+            $token = bin2hex(random_bytes(16));
+            $hash  = hash('sha256', $token);
+            $expira = date('Y-m-d H:i:s', time() + 3600);
+
+            $pdo->prepare('DELETE FROM password_resets WHERE usuario_id = ?')->execute([$user['id']]);
+            $ins = $pdo->prepare('INSERT INTO password_resets (usuario_id, token_hash, expires_at) VALUES (?, ?, ?)');
+            $ins->execute([$user['id'], $hash, $expira]);
+
+            $link = BASE_URL . '/redefinir_senha.php?token=' . $token;
+            $assunto = 'Recuperação de senha';
+            $mensagem = "Olá {$user['nome']},\n\n" .
+                        "Clique no link abaixo para redefinir sua senha:\n" .
+                        "$link\n\n" .
+                        "Se você não solicitou, ignore este e-mail.";
+            @mail($email, $assunto, $mensagem);
+        }
+    }
+    header('Location: recuperar_senha.php?ok=1');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Recuperar Senha - Bastards Brewery</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body class="bg-gray-900 flex items-center justify-center min-h-screen text-white p-4">
+  <div class="bg-gray-800 p-4 sm:p-6 md:p-8 rounded-lg shadow-lg w-full max-w-xs sm:max-w-sm">
+    <h2 class="text-xl sm:text-2xl font-bold text-yellow-400 mb-4 sm:mb-6 text-center">Recuperar Senha</h2>
+    <?php if ($sucesso): ?>
+      <p class="bg-green-500 text-white text-sm p-2 rounded mb-4 text-center">Se o e-mail estiver cadastrado, enviaremos as instruções.</p>
+    <?php endif; ?>
+    <form action="" method="POST" class="space-y-3 sm:space-y-4">
+      <div>
+        <label class="block mb-1 text-sm sm:text-base">E-mail</label>
+        <input type="email" name="email" required class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-white placeholder-gray-400">
+      </div>
+      <button type="submit" class="w-full bg-yellow-500 hover:bg-yellow-600 text-gray-900 font-bold py-2 sm:py-3 px-4 rounded transition duration-200">Enviar</button>
+      <div class="text-center mt-3 sm:mt-4">
+        <a href="login.php" class="text-gray-400 hover:text-yellow-400 transition text-sm sm:text-base">← Voltar ao login</a>
+      </div>
+    </form>
+  </div>
+</body>
+</html>

--- a/redefinir_senha.php
+++ b/redefinir_senha.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/config/db.php';
+require_once __DIR__ . '/config/app.php';
+
+$token = $_GET['token'] ?? '';
+$erro  = $_GET['erro'] ?? '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $token = $_POST['token'] ?? '';
+    $senha = $_POST['senha'] ?? '';
+    $conf  = $_POST['confirmar'] ?? '';
+    if ($senha !== $conf) {
+        header('Location: redefinir_senha.php?token=' . urlencode($token) . '&erro=confirma');
+        exit;
+    }
+    $stmt = $pdo->prepare('SELECT usuario_id FROM password_resets WHERE token_hash = :t AND expires_at > NOW()');
+    $stmt->execute(['t' => hash('sha256', $token)]);
+    $row = $stmt->fetch();
+    if (!$row) {
+        header('Location: recuperar_senha.php?erro=token');
+        exit;
+    }
+    $hash = password_hash($senha, PASSWORD_DEFAULT);
+    $pdo->prepare('UPDATE usuarios SET senha_hash = :h WHERE id = :id')->execute(['h' => $hash, 'id' => $row['usuario_id']]);
+    $pdo->prepare('DELETE FROM password_resets WHERE usuario_id = :id')->execute(['id' => $row['usuario_id']]);
+    header('Location: login.php?msg=senha_redefinida');
+    exit;
+}
+
+// Validação inicial do token
+$stmt = $pdo->prepare('SELECT usuario_id FROM password_resets WHERE token_hash = :t AND expires_at > NOW()');
+$stmt->execute(['t' => hash('sha256', $token)]);
+if (!$stmt->fetch()) {
+    header('Location: recuperar_senha.php?erro=token');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Redefinir Senha - Bastards Brewery</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body class="bg-gray-900 flex items-center justify-center min-h-screen text-white p-4">
+  <div class="bg-gray-800 p-4 sm:p-6 md:p-8 rounded-lg shadow-lg w-full max-w-xs sm:max-w-sm">
+    <h2 class="text-xl sm:text-2xl font-bold text-yellow-400 mb-4 sm:mb-6 text-center">Redefinir Senha</h2>
+    <?php if ($erro === 'confirma'): ?>
+      <p class="bg-red-500 text-white text-sm p-2 rounded mb-4 text-center">A confirmação não confere.</p>
+    <?php endif; ?>
+    <form action="" method="POST" class="space-y-3 sm:space-y-4">
+      <input type="hidden" name="token" value="<?= htmlspecialchars($token) ?>">
+      <div>
+        <label class="block mb-1 text-sm sm:text-base">Nova senha</label>
+        <input type="password" name="senha" required class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-white placeholder-gray-400">
+      </div>
+      <div>
+        <label class="block mb-1 text-sm sm:text-base">Confirmar senha</label>
+        <input type="password" name="confirmar" required class="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-white placeholder-gray-400">
+      </div>
+      <button type="submit" class="w-full bg-yellow-500 hover:bg-yellow-600 text-gray-900 font-bold py-2 sm:py-3 px-4 rounded transition duration-200">Atualizar Senha</button>
+    </form>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Resumo
- adiciona tabela `password_resets` no script do banco
- cria páginas `recuperar_senha.php` e `redefinir_senha.php`
- corrige link de "Esqueceu a senha" na tela de login e exibe toast quando a senha é redefinida

## Testes
- `php -l recuperar_senha.php`
- `php -l redefinir_senha.php`
- `php -l login.php`


------
https://chatgpt.com/codex/tasks/task_e_68839f637eb48321902c455723706f2b