### PR TITLE
Add 'pct' unit option to ficha técnica forms

### DIFF
--- a/modules/ficha_tecnica/cadastrar_ficha.php
+++ b/modules/ficha_tecnica/cadastrar_ficha.php
@@ -114,6 +114,7 @@ include $_SERVER['DOCUMENT_ROOT'] . '/sidebar.php';
                 <option value="ml">ml</option>
                 <option value="LT">LT</option>
                 <option value="UND">UND</option>
+                <option value="pct">pct</option>
               </select>
             </div>
           </div>
@@ -139,6 +140,7 @@ include $_SERVER['DOCUMENT_ROOT'] . '/sidebar.php';
                 <option value="ml">ml</option>
                 <option value="LT">LT</option>
                 <option value="UND">UND</option>
+                <option value="pct">pct</option>
               </select>
             </div>
           </template>

--- a/modules/ficha_tecnica/editar_ficha_form.php
+++ b/modules/ficha_tecnica/editar_ficha_form.php
@@ -174,7 +174,7 @@ $ingredientes = $stmtIng->fetchAll();
                 <label class="text-cyan-300 block mb-1">Unidade</label>
                 <select name="unidade[]" class="w-full p-2 rounded bg-gray-800 border border-gray-700 text-white" required>
                   <?php
-                    $unidades = ['g', 'KG', 'ml', 'LT', 'UND'];
+                    $unidades = ['g', 'KG', 'ml', 'LT', 'UND', 'pct'];
                     foreach ($unidades as $un) {
                       $selected = $un === $ing['unidade'] ? 'selected' : '';
                       echo "<option value=\"$un\" $selected>$un</option>";
@@ -249,6 +249,7 @@ $ingredientes = $stmtIng->fetchAll();
                 <option value="ml">ml</option>
                 <option value="LT">LT</option>
                 <option value="UND">UND</option>
+                <option value="pct">pct</option>
         </select>
       </div>
       <div class="flex justify-center items-end pb-2">


### PR DESCRIPTION
## Summary
- allow choosing `pct` (pacote) as an ingredient unit when creating technical sheets
- support `pct` unit for existing and newly added ingredients when editing technical sheets

## Testing
- `php -l modules/ficha_tecnica/cadastrar_ficha.php`
- `php -l modules/ficha_tecnica/editar_ficha_form.php`


------
https://chatgpt.com/codex/tasks/task_e_6894c24542188321938835d915bda288