### PR TITLE
Padroniza layout do PNG com cópia para e-mail

### DIFF
--- a/modules/fechamentos/fechamentos.php
+++ b/modules/fechamentos/fechamentos.php
@@ -763,16 +763,51 @@ function atualizarBonificacaoGodSave() {
 }
 
 function exportarChoripanPNG() {
-    const card = document.getElementById('card-choripan');
-    if (!card) {
+    const cardOriginal = document.getElementById('card-choripan');
+    if (!cardOriginal) {
         alert('Sem conteúdo do Choripan para exportar.');
         return;
     }
+    const card = cardOriginal.cloneNode(true);
+
+    const estiloHeader = "background-color:#3b568c;font-weight:bold;border:1px solid #ccc;padding:8px;font-size:14px;";
+    const estiloCelula = "border:1px solid #ccc;padding:8px;color:#333;font-size:12px;background-color:#fff;";
+    const estiloTotal  = "background-color:#e5e7eb;font-weight:bold;border:1px solid #ccc;padding:8px;color:#111111;font-size:12px;";
+
+    card.querySelectorAll('table').forEach(table => {
+        table.removeAttribute('class');
+        const linhas = table.querySelectorAll('tr');
+        linhas.forEach((linha, i) => {
+            const celulas = linha.children;
+            for (const celula of celulas) {
+                celula.removeAttribute('class');
+                celula.removeAttribute('style');
+                if (i === 0) {
+                    celula.setAttribute("style", estiloHeader);
+                } else if (
+                    linha.innerText.includes("TOTAL GERAL") ||
+                    linha.innerText.includes("REPASSE")
+                ) {
+                    celula.setAttribute("style", estiloTotal);
+                } else {
+                    celula.setAttribute("style", estiloCelula);
+                }
+            }
+        });
+    });
+
+    const container = document.createElement('div');
+    container.style.position = 'absolute';
+    container.style.left = '-9999px';
+    container.appendChild(card);
+    document.body.appendChild(container);
+
     html2canvas(card).then(canvas => {
         const link = document.createElement('a');
         link.href = canvas.toDataURL('image/png');
         link.download = 'choripan.png';
         link.click();
+        document.body.removeChild(container);
     });
 }
 
@@ -784,11 +819,39 @@ function exportarGodSavePNG() {
     }
     const card = cardOriginal.cloneNode(true);
     card.querySelectorAll('input, button').forEach(el => el.remove());
+
+    const estiloHeader = "background-color:#3b568c;font-weight:bold;border:1px solid #ccc;padding:8px;font-size:14px;";
+    const estiloCelula = "border:1px solid #ccc;padding:8px;color:#333;font-size:12px;background-color:#fff;";
+    const estiloTotal  = "background-color:#e5e7eb;font-weight:bold;border:1px solid #ccc;padding:8px;color:#111111;font-size:12px;";
+
+    card.querySelectorAll('table').forEach(table => {
+        table.removeAttribute('class');
+        const linhas = table.querySelectorAll('tr');
+        linhas.forEach((linha, i) => {
+            const celulas = linha.children;
+            for (const celula of celulas) {
+                celula.removeAttribute('class');
+                celula.removeAttribute('style');
+                if (i === 0) {
+                    celula.setAttribute("style", estiloHeader);
+                } else if (
+                    linha.innerText.includes("TOTAL BASTARDS") ||
+                    linha.innerText.includes("TOTAL ESPECIAIS")
+                ) {
+                    celula.setAttribute("style", estiloTotal);
+                } else {
+                    celula.setAttribute("style", estiloCelula);
+                }
+            }
+        });
+    });
+
     const container = document.createElement('div');
     container.style.position = 'absolute';
     container.style.left = '-9999px';
     container.appendChild(card);
     document.body.appendChild(container);
+
     html2canvas(card).then(canvas => {
         const link = document.createElement('a');
         link.href = canvas.toDataURL('image/png');


### PR DESCRIPTION
## Summary
- Padroniza exportação PNG dos cards Choripan e God Save usando o mesmo estilo aplicado ao copiar para e-mail

## Testing
- `php -l modules/fechamentos/fechamentos.php`


------
https://chatgpt.com/codex/tasks/task_e_68967ad888f48321a637dde86a48acd9