### PR TITLE
Improve audit table contrast

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -237,18 +237,18 @@ main {
 
 /* Melhora o contraste da tabela */
 #tabela-auditoria th {
-  background-color: #374151; /* gray-700 */
-  color: #F9FAFB;            /* gray-50 */
+  background-color: #1F2937; /* gray-800 */
+  color: #FFFFFF;            /* white */
 }
 #tabela-auditoria td {
-  background-color: #1F2937; /* gray-800 */
-  color: #E5E7EB;            /* gray-200 */
+  background-color: #111827; /* gray-900 */
+  color: #F3F4F6;            /* gray-100 */
 }
 #tabela-auditoria tr:nth-child(even) td {
-  background-color: #111827; /* gray-900 */
+  background-color: #1F2937; /* gray-800 */
 }
 #tabela-auditoria tbody tr:hover td {
-  background-color: #4B5563; /* gray-600 */
+  background-color: #374151; /* gray-700 */
 }
 
 /* ---------- Estilos para controles do DataTables (select "Exibir" e input "Pesquisar") ---------- */


### PR DESCRIPTION
## Summary
- darken audit table backgrounds and lighten text for improved contrast

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*
- `python - <<'PY' ...` *(contrast ratios: header 14.0, cells 16.1, even 13.3, hover 9.4)*

------
https://chatgpt.com/codex/tasks/task_e_689fbcfe695c8321914d18def2dbf3b0