### PR TITLE
Fix deprecated filter use causing auditoria warnings

### DIFF
--- a/modules/compras/exportar_pedido.php
+++ b/modules/compras/exportar_pedido.php
@@ -17,10 +17,10 @@ if ($conn->connect_error) {
 }
 
 // 1) Lê filtros com validação e sanitização
-$selFilial   = filter_input(INPUT_GET, 'filial', FILTER_SANITIZE_STRING);
-$dataInicio  = filter_input(INPUT_GET, 'data_inicio', FILTER_SANITIZE_STRING);
-$dataFim     = filter_input(INPUT_GET, 'data_fim', FILTER_SANITIZE_STRING);
-$action      = filter_input(INPUT_GET, 'export', FILTER_SANITIZE_STRING);
+$selFilial   = filter_input(INPUT_GET, 'filial', FILTER_SANITIZE_SPECIAL_CHARS);
+$dataInicio  = filter_input(INPUT_GET, 'data_inicio', FILTER_SANITIZE_SPECIAL_CHARS);
+$dataFim     = filter_input(INPUT_GET, 'data_fim', FILTER_SANITIZE_SPECIAL_CHARS);
+$action      = filter_input(INPUT_GET, 'export', FILTER_SANITIZE_SPECIAL_CHARS);
 
 // Valida datas
 if ($dataInicio && $dataFim) {

--- a/modules/exportar_pedido.php
+++ b/modules/exportar_pedido.php
@@ -17,10 +17,10 @@ if ($conn->connect_error) {
 }
 
 // 1) Lê filtros com validação e sanitização
-$selFilial   = filter_input(INPUT_GET, 'filial', FILTER_SANITIZE_STRING);
-$dataInicio  = filter_input(INPUT_GET, 'data_inicio', FILTER_SANITIZE_STRING);
-$dataFim     = filter_input(INPUT_GET, 'data_fim', FILTER_SANITIZE_STRING);
-$action      = filter_input(INPUT_GET, 'export', FILTER_SANITIZE_STRING);
+$selFilial   = filter_input(INPUT_GET, 'filial', FILTER_SANITIZE_SPECIAL_CHARS);
+$dataInicio  = filter_input(INPUT_GET, 'data_inicio', FILTER_SANITIZE_SPECIAL_CHARS);
+$dataFim     = filter_input(INPUT_GET, 'data_fim', FILTER_SANITIZE_SPECIAL_CHARS);
+$action      = filter_input(INPUT_GET, 'export', FILTER_SANITIZE_SPECIAL_CHARS);
 
 // Valida datas
 if ($dataInicio && $dataFim) {

--- a/modules/ficha_tecnica/processar_auditoria.php
+++ b/modules/ficha_tecnica/processar_auditoria.php
@@ -1,19 +1,19 @@
 <?php
 require_once '../../config/db.php';
 
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
+// Remover exibição de erros para evitar saída antes do redirecionamento
+// As configurações de erro devem ser definidas no ambiente, não no código
+
 
 // Verificar se o formulário foi enviado
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // Validar e sanitizar os dados do formulário
     $ficha_id = filter_input(INPUT_POST, 'ficha_id', FILTER_VALIDATE_INT);
-    $auditor = filter_input(INPUT_POST, 'auditor', FILTER_SANITIZE_STRING);
-    $data_auditoria = filter_input(INPUT_POST, 'data_auditoria', FILTER_SANITIZE_STRING);
-    $cozinheiro = filter_input(INPUT_POST, 'cozinheiro', FILTER_SANITIZE_STRING);
-    $status_auditoria = filter_input(INPUT_POST, 'status_auditoria', FILTER_SANITIZE_STRING);
-    $observacoes = filter_input(INPUT_POST, 'observacoes', FILTER_SANITIZE_STRING);
+    $auditor = filter_input(INPUT_POST, 'auditor', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+    $data_auditoria = filter_input(INPUT_POST, 'data_auditoria', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+    $cozinheiro = filter_input(INPUT_POST, 'cozinheiro', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+    $status_auditoria = filter_input(INPUT_POST, 'status_auditoria', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+    $observacoes = filter_input(INPUT_POST, 'observacoes', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
     $periodicidade = filter_input(INPUT_POST, 'periodicidade', FILTER_VALIDATE_INT) ?: 30; // Padrão: 30 dias
     
     // Validar dados obrigatórios

--- a/modules/forms/telegram_config.php
+++ b/modules/forms/telegram_config.php
@@ -9,12 +9,12 @@ use Modules\Forms\Model\FormModel;
 
 // 1) Handle POST actions: adicionar, excluir destinatário, salvar template, enviar teste
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $action = filter_input(INPUT_POST, 'action', FILTER_SANITIZE_STRING);
+    $action = filter_input(INPUT_POST, 'action', FILTER_SANITIZE_SPECIAL_CHARS);
 
     // 1.1) Adicionar ou atualizar destinatário
     if ($action === 'save_recipient') {
         $chatId      = filter_input(INPUT_POST, 'chat_id', FILTER_SANITIZE_NUMBER_INT);
-        $description = trim(filter_input(INPUT_POST, 'description', FILTER_SANITIZE_STRING));
+        $description = trim(filter_input(INPUT_POST, 'description', FILTER_SANITIZE_SPECIAL_CHARS));
         $assigned    = filter_input(INPUT_POST, 'forms', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY) ?: [];
 
         if ($chatId && $description !== '') {


### PR DESCRIPTION
## Summary
- Remove inline error display to prevent output before redirects
- Sanitize audit form fields with `FILTER_SANITIZE_FULL_SPECIAL_CHARS`

## Testing
- `php -l modules/ficha_tecnica/processar_auditoria.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae0ff194c083218ee1b731bc651124