### PR TITLE
Ensure Cloudify lookups respect selected base

### DIFF
--- a/modules/ficha_tecnica/README.md
+++ b/modules/ficha_tecnica/README.md
@@ -1,5 +1,21 @@
 ## 🆕 Novidades da versão 1.5.2
 
+## 🆕 Divisão das bases WAB/BDF
+
+- Todas as importações (XLSX de produtos e CSV de insumos) agora pedem que você escolha entre as bases **WAB** ou **BDF** antes de enviar o arquivo.
+- O cadastro e a edição de fichas técnicas incluem a seleção da base de origem, garantindo que consultas, comparações e cálculos usem os dados corretos.
+- As telas de consulta, comparação e visualização passam a respeitar a base armazenada na ficha técnica ao buscar informações no DW.
+
+### ⚙️ Preparação do banco de dados
+
+Antes de usar os novos recursos, execute uma única vez o script abaixo para criar as tabelas espelhadas no DW, copiar os dados atuais e adicionar o campo `base_origem` na tabela `ficha_tecnica`:
+
+```bash
+php scripts/create_dw_split_tables.php
+```
+
+> O script é idempotente: ele cria as tabelas `ProdutosBares_WAB/BDF` e `insumos_bastards_wab/bdf` caso não existam, replica os dados apenas quando a tabela está vazia e adiciona a coluna `base_origem` com valor padrão `WAB`.
+
 A versão **v1.5.2** aplica o **UX Layout Guide v1.6** em todo o sistema com foco em responsividade e acessibilidade. Nenhuma funcionalidade foi alterada — apenas o layout foi melhorado para oferecer melhor experiência em diferentes dispositivos.
 
 ### 🎨 Ajustes visuais aplicados:

--- a/modules/ficha_tecnica/buscar_insumos.php
+++ b/modules/ficha_tecnica/buscar_insumos.php
@@ -1,12 +1,24 @@
 <?php
 require_once '../../config/db_dw.php';
 
+$validBases = ['WAB', 'BDF'];
+$base = strtoupper($_POST['base'] ?? 'WAB');
+if (!in_array($base, $validBases, true)) {
+    http_response_code(400);
+    echo json_encode([]);
+    exit;
+}
+
+$tabelaProdutos = $base === 'BDF' ? 'ProdutosBares_BDF' : 'ProdutosBares_WAB';
+
 $codigo = $_POST['codigo'] ?? null;
 $termo = $_POST['termo'] ?? '';
 
+header('Content-Type: application/json');
+
 if ($codigo) {
     $stmt = $pdo_dw->prepare("SELECT `Nome` as Insumo, `Cód. Ref.` AS codigo, `Unidade` AS unidade, `Custo médio` AS custo
-                              FROM ProdutosBares
+                              FROM `$tabelaProdutos`
                               WHERE `Cód. Ref.` = :codigo
                               LIMIT 1");
     $stmt->execute([':codigo' => $codigo]);
@@ -20,7 +32,7 @@ if (strlen($termo) < 2) {
 }
 
 $stmt = $pdo_dw->prepare("SELECT `Nome` as Insumo, `Cód. Ref.` AS codigo, `Unidade` AS unidade
-                           FROM ProdutosBares
+                           FROM `$tabelaProdutos`
                            WHERE `Nome` LIKE :termo
                            LIMIT 20");
 $stmt->execute([':termo' => '%' . $termo . '%']);

--- a/modules/ficha_tecnica/buscar_prato.php
+++ b/modules/ficha_tecnica/buscar_prato.php
@@ -1,7 +1,19 @@
 <?php
 require_once '../../config/db_dw.php';
 
+$validBases = ['WAB', 'BDF'];
+$base = strtoupper($_POST['base'] ?? 'WAB');
+if (!in_array($base, $validBases, true)) {
+    http_response_code(400);
+    echo json_encode([]);
+    exit;
+}
+
+$tabelaInsumos = $base === 'BDF' ? 'insumos_bastards_bdf' : 'insumos_bastards_wab';
+
 $codigo = $_POST['codigo_cloudify'] ?? null;
+
+header('Content-Type: application/json');
 
 if (!$codigo) {
     echo json_encode([]);
@@ -9,7 +21,7 @@ if (!$codigo) {
 }
 
 $stmt = $pdo_dw->prepare("SELECT `Produto` AS nome_prato
-                          FROM insumos_bastards
+                          FROM `$tabelaInsumos`
                           WHERE `Cód. ref.` = :codigo
                           LIMIT 1");
 $stmt->execute([':codigo' => $codigo]);

--- a/modules/ficha_tecnica/salvar_edicao.php
+++ b/modules/ficha_tecnica/salvar_edicao.php
@@ -55,6 +55,11 @@ try {
     $responsavel = $_POST['usuario']; // <-- campo do formulário
     $usuario_logado = $_SESSION['usuario_nome'] ?? 'sistema'; // <-- nome do usuário logado
     $cloudify   = $_POST['codigo_cloudify'] ?? '';
+    $base_origem = strtoupper($_POST['base_origem'] ?? 'WAB');
+
+    if (!in_array($base_origem, ['WAB', 'BDF'], true)) {
+        throw new Exception('Base de origem inválida.');
+    }
 
     $descricao  = $_POST['descricao'];
     $quantidade = $_POST['quantidade'];
@@ -98,11 +103,11 @@ try {
     }
 
     // Atualizar ficha técnica
-    $stmt = $pdo->prepare("UPDATE ficha_tecnica SET 
-        nome_prato = :nome, rendimento = :rendimento, modo_preparo = :modo, 
-        imagem = :imagem, usuario = :responsavel, codigo_cloudify = :codigo, 
-        ativo_wab = :ativo_wab, ativo_bdf_noite = :ativo_bdf_noite, ativo_bdf_almoco = :ativo_bdf_almoco, 
-        ativo_bdf_almoco_fds = :ativo_bdf_almoco_fds 
+    $stmt = $pdo->prepare("UPDATE ficha_tecnica SET
+        nome_prato = :nome, rendimento = :rendimento, modo_preparo = :modo,
+        imagem = :imagem, usuario = :responsavel, codigo_cloudify = :codigo, base_origem = :base_origem,
+        ativo_wab = :ativo_wab, ativo_bdf_noite = :ativo_bdf_noite, ativo_bdf_almoco = :ativo_bdf_almoco,
+        ativo_bdf_almoco_fds = :ativo_bdf_almoco_fds
         WHERE id = :id");
         
     $stmt->execute([
@@ -112,6 +117,7 @@ try {
         ':imagem'     => $imagem_nome,
         ':responsavel'=> $responsavel,
         ':codigo'     => $cloudify,
+        ':base_origem'=> $base_origem,
         ':ativo_wab'  => $ativo_wab,
         ':ativo_bdf_almoco'     => $ativo_bdf_almoco,
         ':ativo_bdf_almoco_fds' => $ativo_bdf_almoco_fds,
@@ -126,6 +132,7 @@ try {
         'modo_preparo'    => $modo,
         'usuario'         => $responsavel, // aqui continua como "usuario" pois é o nome do campo na tabela
         'codigo_cloudify' => $cloudify,
+        'base_origem'     => $base_origem,
         'ativo_wab'       => $ativo_wab,
         'ativo_bdf_almoco'     => $ativo_bdf_almoco,
         'ativo_bdf_almoco_fds' => $ativo_bdf_almoco_fds,

--- a/modules/ficha_tecnica/salvar_ficha.php
+++ b/modules/ficha_tecnica/salvar_ficha.php
@@ -38,7 +38,12 @@ try {
     $modo_preparo    = $_POST['modo_preparo'];
     $responsavel     = $_POST['usuario']; // este vai para ficha
     $codigo_cloudify = $_POST['codigo_cloudify'] ?? null;
+    $base_origem     = strtoupper($_POST['base_origem'] ?? 'WAB');
     $usuario_logado  = $_SESSION['usuario_nome'] ?? 'sistema'; // este vai para histórico
+
+    if (!in_array($base_origem, ['WAB', 'BDF'], true)) {
+        throw new Exception('Base de origem inválida. Selecione WAB ou BDF.');
+    }
 
     $ingredientes = $_POST['descricao'] ?? [];
     $codigos      = $_POST['codigo'] ?? [];
@@ -72,16 +77,17 @@ try {
     }
 
     // 📝 Inserir ficha técnica
-    $stmt = $pdo->prepare("INSERT INTO ficha_tecnica 
-        (nome_prato, rendimento, modo_preparo, imagem, usuario, codigo_cloudify)
-        VALUES (:nome, :rendimento, :modo, :imagem, :usuario, :cloudify)");
+    $stmt = $pdo->prepare("INSERT INTO ficha_tecnica
+        (nome_prato, rendimento, modo_preparo, imagem, usuario, codigo_cloudify, base_origem)
+        VALUES (:nome, :rendimento, :modo, :imagem, :usuario, :cloudify, :base)");
     $stmt->execute([
         ':nome'      => $nome,
         ':rendimento'=> $rendimento,
         ':modo'      => $modo_preparo,
         ':imagem'    => $imagem_nome,
         ':usuario'   => $responsavel,
-        ':cloudify'  => $codigo_cloudify
+        ':cloudify'  => $codigo_cloudify,
+        ':base'      => $base_origem
     ]);
 
     $ficha_id = $pdo->lastInsertId();

--- a/modules/ficha_tecnica/visualizar_ficha.php
+++ b/modules/ficha_tecnica/visualizar_ficha.php
@@ -22,6 +22,13 @@ if (!$ficha) {
     exit('Ficha não encontrada.');
 }
 
+$baseOrigem = strtoupper($ficha['base_origem'] ?? 'WAB');
+$validBases = ['WAB', 'BDF'];
+if (!in_array($baseOrigem, $validBases, true)) {
+    $baseOrigem = 'WAB';
+}
+$tabelaInsumos = $baseOrigem === 'BDF' ? 'insumos_bastards_bdf' : 'insumos_bastards_wab';
+
 // 4) Fetch dos ingredientes
 $stmtIngs = $pdo->prepare('SELECT codigo, descricao, quantidade, unidade FROM ingredientes WHERE ficha_id = :id');
 $stmtIngs->execute([':id' => $id]);
@@ -32,7 +39,7 @@ $codigos = array_column($ingredientes, 'codigo');
 if ($codigos) {
     $placeholders = implode(',', array_fill(0, count($codigos), '?'));
     $sqlCusto = "SELECT `CODIGO` AS codigo, COALESCE(`Custo unit..1`,0) AS custo_unitario
-                 FROM insumos_bastards
+                 FROM `$tabelaInsumos`
                  WHERE `CODIGO` IN ($placeholders)";
     $stmtC = $pdo_dw->prepare($sqlCusto);
     $stmtC->execute($codigos);
@@ -147,6 +154,7 @@ if ($codigos) {
       <p><strong>Rendimento:</strong> <?= htmlspecialchars($ficha['rendimento'], ENT_QUOTES) ?></p>
       <p><strong>Responsável:</strong> <?= htmlspecialchars($ficha['usuario'], ENT_QUOTES) ?></p>
       <p><strong>Código Cloudify:</strong> <?= htmlspecialchars($ficha['codigo_cloudify'], ENT_QUOTES) ?></p>
+      <p><strong>Base de origem:</strong> <?= htmlspecialchars($baseOrigem, ENT_QUOTES) ?></p>
       <p><strong>Data:</strong> <?= date('d/m/Y H:i', strtotime($ficha['data_criacao'])) ?></p>
     </div>
 

--- a/scripts/create_dw_split_tables.php
+++ b/scripts/create_dw_split_tables.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../config/db_dw.php';
+require_once __DIR__ . '/../config/db.php';
+
+$dwTables = [
+    ['source' => 'ProdutosBares', 'target' => 'ProdutosBares_WAB'],
+    ['source' => 'ProdutosBares', 'target' => 'ProdutosBares_BDF'],
+    ['source' => 'insumos_bastards', 'target' => 'insumos_bastards_wab'],
+    ['source' => 'insumos_bastards', 'target' => 'insumos_bastards_bdf'],
+];
+
+try {
+    foreach ($dwTables as $pair) {
+        $source = $pair['source'];
+        $target = $pair['target'];
+
+        $pdo_dw->exec("CREATE TABLE IF NOT EXISTS `$target` LIKE `$source`");
+
+        $stmt = $pdo_dw->query("SELECT COUNT(*) FROM `$target`");
+        $rowCount = (int) $stmt->fetchColumn();
+
+        if ($rowCount === 0) {
+            $copied = $pdo_dw->exec("INSERT INTO `$target` SELECT * FROM `$source`");
+            echo "Tabela `$target` criada e preenchida com $copied registros de `$source`.\n";
+        } else {
+            echo "Tabela `$target` já possui $rowCount registros. Nenhuma cópia necessária.\n";
+        }
+    }
+
+    $colCheck = $pdo->prepare(
+        "SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ficha_tecnica' AND COLUMN_NAME = 'base_origem'"
+    );
+    $colCheck->execute();
+
+    if ((int) $colCheck->fetchColumn() === 0) {
+        $pdo->exec("ALTER TABLE ficha_tecnica ADD COLUMN base_origem ENUM('WAB','BDF') NOT NULL DEFAULT 'WAB' AFTER codigo_cloudify");
+        $pdo->exec("UPDATE ficha_tecnica SET base_origem = 'WAB' WHERE base_origem IS NULL OR base_origem = ''");
+        echo "Coluna base_origem criada em ficha_tecnica e preenchida com 'WAB'.\n";
+    } else {
+        echo "Coluna base_origem já existe em ficha_tecnica.\n";
+    }
+
+    echo "✅ Estruturas do DW e tabela ficha_tecnica verificadas com sucesso.\n";
+} catch (PDOException $exception) {
+    fwrite(STDERR, "Erro ao preparar tabelas divididas: " . $exception->getMessage() . "\n");
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- refresh the Cloudify name lookup on ficha creation to re-query with the currently selected base and clear stale values when bases change
- mirror the same base-aware lookup behaviour on the edit form so switching WAB/BDF updates the fetched product name accordingly

## Testing
- php -l modules/ficha_tecnica/cadastrar_ficha.php
- php -l modules/ficha_tecnica/editar_ficha_form.php

------
https://chatgpt.com/codex/tasks/task_e_68cd6645241c832181b2359b6d5b0e38