### PR TITLE
Evitar que busca de prato mantenha dados da base anterior

### DIFF
--- a/modules/ficha_tecnica/editar_ficha_form.php
+++ b/modules/ficha_tecnica/editar_ficha_form.php
@@ -372,38 +372,70 @@ $ingredientes = $stmtIng->fetchAll();
         }
       });
     }
-    
+
+    let ultimaBuscaPratoToken = 0;
+
+    function buscarPratoPorCodigo() {
+      const codInput = document.getElementById('codigo_cloudify');
+      const nomeInput = document.getElementById('nome_prato');
+
+      if (!codInput || !nomeInput) {
+        return;
+      }
+
+      const codigo = codInput.value.trim();
+      const baseSelecionada = obterBaseSelecionada();
+      const tokenAtual = ++ultimaBuscaPratoToken;
+
+      if (!codigo) {
+        nomeInput.value = '';
+        nomeInput.dataset.baseOrigem = '';
+        return;
+      }
+
+      fetch('buscar_prato.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'codigo_cloudify=' + encodeURIComponent(codigo) + '&base=' + encodeURIComponent(baseSelecionada)
+      })
+      .then(res => res.json())
+      .then(data => {
+        if (tokenAtual !== ultimaBuscaPratoToken) {
+          return;
+        }
+
+        if (data && data.nome_prato) {
+          nomeInput.value = data.nome_prato;
+          nomeInput.dataset.baseOrigem = baseSelecionada;
+        } else {
+          nomeInput.value = '';
+          nomeInput.dataset.baseOrigem = '';
+        }
+      })
+      .catch(err => {
+        if (tokenAtual === ultimaBuscaPratoToken) {
+          nomeInput.value = '';
+          nomeInput.dataset.baseOrigem = '';
+        }
+        console.error('Erro ao buscar prato:', err);
+      });
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
       const codInput = document.getElementById('codigo_cloudify');
       const nomeInput = document.getElementById('nome_prato');
 
       if (codInput && nomeInput) {
-        codInput.addEventListener('blur', function () {
-          const codigo = this.value.trim();
-          if (!codigo) return;
-
-          fetch('buscar_prato.php', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: 'codigo_cloudify=' + encodeURIComponent(codigo) + '&base=' + encodeURIComponent(obterBaseSelecionada())
-          })
-          .then(res => res.json())
-          .then(data => {
-            console.log("Retorno:", data); // Para depuração
-            if (data && data.nome_prato) {
-              nomeInput.value = data.nome_prato;
-            }
-          })
-          .catch(err => console.error("Erro:", err));
-        });
+        codInput.addEventListener('blur', buscarPratoPorCodigo);
       }
-      
+
       // 👇 Esta linha resolve o problema para os campos já carregados
       aplicarBuscaPorCodigo();
 
       document.querySelectorAll('input[name="base_origem"]').forEach(radio => {
         radio.addEventListener('change', () => {
           buscarInsumo();
+          buscarPratoPorCodigo();
         });
       });
     });


### PR DESCRIPTION
## Summary
- centralize the Cloudify code lookup used to fill Nome do Prato
- ensure the lookup is re-executed when the base de origem selection changes in both forms
- prevent stale prato names from lingering when the selected base changes by clearing outdated values and ignoring late responses

## Testing
- php -l modules/ficha_tecnica/cadastrar_ficha.php
- php -l modules/ficha_tecnica/editar_ficha_form.php

------
https://chatgpt.com/codex/tasks/task_e_68d3f26665fc832183150ad7e9dedbfe